### PR TITLE
Add Rest week handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ This tool:
 
 ```bash
 pip install pandas numpy orjson python-dateutil rich
+```
+
+### Rest Weeks
+
+Add a week to your plan with `"drill": "Rest"` to skip training and recover extra
+fatigue and stress. The simulator applies an additional **-20 fatigue** and
+**-10 stress** on top of normal weekly recovery when it encounters a Rest entry.

--- a/planner_schedule.json
+++ b/planner_schedule.json
@@ -19,7 +19,8 @@
 { "week": 17, "drill": "Meditate", "item": "Nuts Oil", "notes": "praise" },
 { "week": 18, "drill": "Leap", "item": "Mint Leaf", "notes": "praise; scold only on failure" },
 { "week": 19, "drill": "Dodge", "item": "Candy", "notes": "praise" },
-{ "week": 20, "drill": "Meditate", "item": "Nuts Oil", "notes": "praise; loyalty should surpass 50" }
+    { "week": 20, "drill": "Meditate", "item": "Nuts Oil", "notes": "praise; loyalty should surpass 50" }
+    ,{ "week": 21, "drill": "Rest", "item": "None", "notes": "take a break for recovery" }
 ],
 "totals": { "INT": 120, "SPD": 88, "fatigue_peak": 28, "stress_peak": 18, "loyalty_final": 54 },
 "warnings": [ "Schedule uses approximate drill effects; exact stat gains may vary." ]

--- a/simulate_schedule.py
+++ b/simulate_schedule.py
@@ -55,25 +55,30 @@ for week_entry in schedule_data['schedule']:
         fatigue = max(0, fatigue - NAT_FATIGUE_RECOVER)
         stress = max(0, stress - NAT_STRESS_RECOVER)
 
-    d = drill_info[drill]
-    heavy = d['type'] == 'Heavy'
+    if drill == 'Rest':
+        # additional recovery when resting
+        fatigue = max(0, fatigue - 20)
+        stress = max(0, stress - 10)
+    else:
+        d = drill_info[drill]
+        heavy = d['type'] == 'Heavy'
 
-    # apply drill stats
-    main_stat = d['main+'].upper()
-    sub_stat = d.get('sub+')
-    drop_stat = d.get('drop-')
+        # apply drill stats
+        main_stat = d['main+'].upper()
+        sub_stat = d.get('sub+')
+        drop_stat = d.get('drop-')
 
-    stats[main_stat] = stats.get(main_stat, 0) + (12 if heavy else 4)
-    if sub_stat:
-        stats[sub_stat.upper()] = stats.get(sub_stat.upper(), 0) + (4 if heavy else 0)
-    if drop_stat:
-        stats[drop_stat.upper()] = stats.get(drop_stat.upper(), 0) - (4 if heavy else 0)
+        stats[main_stat] = stats.get(main_stat, 0) + (12 if heavy else 4)
+        if sub_stat:
+            stats[sub_stat.upper()] = stats.get(sub_stat.upper(), 0) + (4 if heavy else 0)
+        if drop_stat:
+            stats[drop_stat.upper()] = stats.get(drop_stat.upper(), 0) - (4 if heavy else 0)
 
-    stress += d['stresschange']
-    fatigue += d['fatiguechange']
+        stress += d['stresschange']
+        fatigue += d['fatiguechange']
 
-    # praise after drill
-    loyalty += 1
+        # praise after drill
+        loyalty += 1
 
     # apply item
     fatigue, stress, loyalty = apply_item(item, fatigue, stress, loyalty)


### PR DESCRIPTION
## Summary
- support a `Rest` entry in the planner schedule with no stats gained
- apply extra -20 fatigue and -10 stress recovery during rest weeks
- document how to use Rest weeks in the README

## Testing
- `python simulate_schedule.py > /tmp/out.json && tail -n 5 /tmp/out.json`