### PR TITLE
Optimize schedule to avoid stress breaches

### DIFF
--- a/planner_schedule.json
+++ b/planner_schedule.json
@@ -4,7 +4,7 @@
       "week": 1,
       "drill": "Meditate",
       "item": "Nuts Oil",
-      "notes": "praise after drill \u2013 start loyalty building"
+      "notes": "praise after drill – start loyalty building"
     },
     {
       "week": 2,
@@ -87,13 +87,13 @@
     {
       "week": 15,
       "drill": "Leap",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": "praise; mint offsets stress spike"
     },
     {
       "week": 16,
       "drill": "Study",
-      "item": "Mango",
+      "item": "None",
       "notes": "praise; a little fatigue relief"
     },
     {
@@ -104,7 +104,7 @@
     },
     {
       "week": 18,
-      "drill": "Leap",
+      "drill": "Rest",
       "item": "None",
       "notes": "praise; scold only on failure"
     },

--- a/simulator_output_mod.json
+++ b/simulator_output_mod.json
@@ -1,0 +1,310 @@
+{
+  "run_log": [
+    {
+      "week": 1,
+      "stats": {
+        "LIF": 168,
+        "POW": 87,
+        "INT": 183,
+        "SKI": 186,
+        "SPD": 172,
+        "DEF": 44
+      },
+      "fatigue": 0,
+      "stress": 9.6,
+      "loyalty": 52
+    },
+    {
+      "week": 2,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 187,
+        "SKI": 186,
+        "SPD": 184,
+        "DEF": 44
+      },
+      "fatigue": 15,
+      "stress": 16.6,
+      "loyalty": 53
+    },
+    {
+      "week": 3,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 187,
+        "SKI": 186,
+        "SPD": 188,
+        "DEF": 44
+      },
+      "fatigue": 15,
+      "stress": 8.3,
+      "loyalty": 53
+    },
+    {
+      "week": 4,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 199,
+        "SKI": 190,
+        "SPD": 188,
+        "DEF": 40
+      },
+      "fatigue": 20,
+      "stress": 15.3,
+      "loyalty": 54
+    },
+    {
+      "week": 5,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 203,
+        "SKI": 190,
+        "SPD": 188,
+        "DEF": 40
+      },
+      "fatigue": 20,
+      "stress": 7.65,
+      "loyalty": 54
+    },
+    {
+      "week": 6,
+      "stats": {
+        "LIF": 168,
+        "POW": 79,
+        "INT": 207,
+        "SKI": 190,
+        "SPD": 200,
+        "DEF": 40
+      },
+      "fatigue": 25,
+      "stress": 14.65,
+      "loyalty": 55
+    },
+    {
+      "week": 7,
+      "stats": {
+        "LIF": 168,
+        "POW": 79,
+        "INT": 207,
+        "SKI": 190,
+        "SPD": 204,
+        "DEF": 40
+      },
+      "fatigue": 25,
+      "stress": 14.65,
+      "loyalty": 56
+    },
+    {
+      "week": 8,
+      "stats": {
+        "LIF": 168,
+        "POW": 79,
+        "INT": 219,
+        "SKI": 194,
+        "SPD": 204,
+        "DEF": 36
+      },
+      "fatigue": 2,
+      "stress": 17.32,
+      "loyalty": 58
+    },
+    {
+      "week": 9,
+      "stats": {
+        "LIF": 168,
+        "POW": 75,
+        "INT": 223,
+        "SKI": 194,
+        "SPD": 216,
+        "DEF": 36
+      },
+      "fatigue": 15,
+      "stress": 12.16,
+      "loyalty": 58
+    },
+    {
+      "week": 10,
+      "stats": {
+        "LIF": 168,
+        "POW": 75,
+        "INT": 227,
+        "SKI": 194,
+        "SPD": 216,
+        "DEF": 36
+      },
+      "fatigue": 15,
+      "stress": 12.16,
+      "loyalty": 59
+    },
+    {
+      "week": 11,
+      "stats": {
+        "LIF": 168,
+        "POW": 75,
+        "INT": 239,
+        "SKI": 198,
+        "SPD": 216,
+        "DEF": 32
+      },
+      "fatigue": 20,
+      "stress": 19.16,
+      "loyalty": 60
+    },
+    {
+      "week": 12,
+      "stats": {
+        "LIF": 168,
+        "POW": 71,
+        "INT": 243,
+        "SKI": 198,
+        "SPD": 228,
+        "DEF": 32
+      },
+      "fatigue": 0,
+      "stress": 20.93,
+      "loyalty": 62
+    },
+    {
+      "week": 13,
+      "stats": {
+        "LIF": 168,
+        "POW": 71,
+        "INT": 243,
+        "SKI": 198,
+        "SPD": 232,
+        "DEF": 32
+      },
+      "fatigue": 10,
+      "stress": 18.93,
+      "loyalty": 64
+    },
+    {
+      "week": 14,
+      "stats": {
+        "LIF": 168,
+        "POW": 71,
+        "INT": 255,
+        "SKI": 202,
+        "SPD": 232,
+        "DEF": 28
+      },
+      "fatigue": 15,
+      "stress": 25.93,
+      "loyalty": 65
+    },
+    {
+      "week": 15,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 259,
+        "SKI": 202,
+        "SPD": 244,
+        "DEF": 28
+      },
+      "fatigue": 20,
+      "stress": 16.46,
+      "loyalty": 65
+    },
+    {
+      "week": 16,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 263,
+        "SKI": 202,
+        "SPD": 244,
+        "DEF": 28
+      },
+      "fatigue": 20,
+      "stress": 16.46,
+      "loyalty": 66
+    },
+    {
+      "week": 17,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 275,
+        "SKI": 206,
+        "SPD": 244,
+        "DEF": 24
+      },
+      "fatigue": 0,
+      "stress": 18.77,
+      "loyalty": 68
+    },
+    {
+      "week": 18,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 275,
+        "SKI": 206,
+        "SPD": 244,
+        "DEF": 24
+      },
+      "fatigue": 0,
+      "stress": 3.77,
+      "loyalty": 68
+    },
+    {
+      "week": 19,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 275,
+        "SKI": 206,
+        "SPD": 248,
+        "DEF": 24
+      },
+      "fatigue": 10,
+      "stress": 3,
+      "loyalty": 70
+    },
+    {
+      "week": 20,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 287,
+        "SKI": 210,
+        "SPD": 248,
+        "DEF": 20
+      },
+      "fatigue": 15,
+      "stress": 12,
+      "loyalty": 71
+    },
+    {
+      "week": 21,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 287,
+        "SKI": 210,
+        "SPD": 248,
+        "DEF": 20
+      },
+      "fatigue": 0,
+      "stress": 0,
+      "loyalty": 71
+    }
+  ],
+  "final_stats": {
+    "LIF": 168,
+    "POW": 67,
+    "INT": 287,
+    "SKI": 210,
+    "SPD": 248,
+    "DEF": 20,
+    "loyalty": 71
+  },
+  "breaches": [],
+  "sim_notes": "Simulated 21 weeks. Lifespan used: 21.",
+  "warnings": []
+}

--- a/simulator_output_new.json
+++ b/simulator_output_new.json
@@ -1,0 +1,341 @@
+{
+  "run_log": [
+    {
+      "week": 1,
+      "stats": {
+        "LIF": 168,
+        "POW": 87,
+        "INT": 183,
+        "SKI": 186,
+        "SPD": 172,
+        "DEF": 44
+      },
+      "fatigue": 0,
+      "stress": 9.6,
+      "loyalty": 52
+    },
+    {
+      "week": 2,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 187,
+        "SKI": 186,
+        "SPD": 184,
+        "DEF": 44
+      },
+      "fatigue": 15,
+      "stress": 16.6,
+      "loyalty": 53
+    },
+    {
+      "week": 3,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 187,
+        "SKI": 186,
+        "SPD": 188,
+        "DEF": 44
+      },
+      "fatigue": 15,
+      "stress": 8.3,
+      "loyalty": 53
+    },
+    {
+      "week": 4,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 199,
+        "SKI": 190,
+        "SPD": 188,
+        "DEF": 40
+      },
+      "fatigue": 20,
+      "stress": 15.3,
+      "loyalty": 54
+    },
+    {
+      "week": 5,
+      "stats": {
+        "LIF": 168,
+        "POW": 83,
+        "INT": 203,
+        "SKI": 190,
+        "SPD": 188,
+        "DEF": 40
+      },
+      "fatigue": 20,
+      "stress": 7.65,
+      "loyalty": 54
+    },
+    {
+      "week": 6,
+      "stats": {
+        "LIF": 168,
+        "POW": 79,
+        "INT": 207,
+        "SKI": 190,
+        "SPD": 200,
+        "DEF": 40
+      },
+      "fatigue": 25,
+      "stress": 14.65,
+      "loyalty": 55
+    },
+    {
+      "week": 7,
+      "stats": {
+        "LIF": 168,
+        "POW": 79,
+        "INT": 207,
+        "SKI": 190,
+        "SPD": 204,
+        "DEF": 40
+      },
+      "fatigue": 25,
+      "stress": 14.65,
+      "loyalty": 56
+    },
+    {
+      "week": 8,
+      "stats": {
+        "LIF": 168,
+        "POW": 79,
+        "INT": 219,
+        "SKI": 194,
+        "SPD": 204,
+        "DEF": 36
+      },
+      "fatigue": 2,
+      "stress": 17.32,
+      "loyalty": 58
+    },
+    {
+      "week": 9,
+      "stats": {
+        "LIF": 168,
+        "POW": 75,
+        "INT": 223,
+        "SKI": 194,
+        "SPD": 216,
+        "DEF": 36
+      },
+      "fatigue": 15,
+      "stress": 12.16,
+      "loyalty": 58
+    },
+    {
+      "week": 10,
+      "stats": {
+        "LIF": 168,
+        "POW": 75,
+        "INT": 227,
+        "SKI": 194,
+        "SPD": 216,
+        "DEF": 36
+      },
+      "fatigue": 15,
+      "stress": 12.16,
+      "loyalty": 59
+    },
+    {
+      "week": 11,
+      "stats": {
+        "LIF": 168,
+        "POW": 75,
+        "INT": 239,
+        "SKI": 198,
+        "SPD": 216,
+        "DEF": 32
+      },
+      "fatigue": 20,
+      "stress": 19.16,
+      "loyalty": 60
+    },
+    {
+      "week": 12,
+      "stats": {
+        "LIF": 168,
+        "POW": 71,
+        "INT": 243,
+        "SKI": 198,
+        "SPD": 228,
+        "DEF": 32
+      },
+      "fatigue": 0,
+      "stress": 20.93,
+      "loyalty": 62
+    },
+    {
+      "week": 13,
+      "stats": {
+        "LIF": 168,
+        "POW": 71,
+        "INT": 243,
+        "SKI": 198,
+        "SPD": 232,
+        "DEF": 32
+      },
+      "fatigue": 10,
+      "stress": 18.93,
+      "loyalty": 64
+    },
+    {
+      "week": 14,
+      "stats": {
+        "LIF": 168,
+        "POW": 71,
+        "INT": 255,
+        "SKI": 202,
+        "SPD": 232,
+        "DEF": 28
+      },
+      "fatigue": 15,
+      "stress": 25.93,
+      "loyalty": 65
+    },
+    {
+      "week": 15,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 259,
+        "SKI": 202,
+        "SPD": 244,
+        "DEF": 28
+      },
+      "fatigue": 20,
+      "stress": 32.93,
+      "loyalty": 66
+    },
+    {
+      "week": 16,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 263,
+        "SKI": 202,
+        "SPD": 244,
+        "DEF": 28
+      },
+      "fatigue": 10,
+      "stress": 32.93,
+      "loyalty": 68
+    },
+    {
+      "week": 17,
+      "stats": {
+        "LIF": 168,
+        "POW": 67,
+        "INT": 275,
+        "SKI": 206,
+        "SPD": 244,
+        "DEF": 24
+      },
+      "fatigue": 0,
+      "stress": 31.94,
+      "loyalty": 70
+    },
+    {
+      "week": 18,
+      "stats": {
+        "LIF": 168,
+        "POW": 63,
+        "INT": 279,
+        "SKI": 206,
+        "SPD": 256,
+        "DEF": 24
+      },
+      "fatigue": 15,
+      "stress": 38.94,
+      "loyalty": 71
+    },
+    {
+      "week": 19,
+      "stats": {
+        "LIF": 168,
+        "POW": 63,
+        "INT": 279,
+        "SKI": 206,
+        "SPD": 260,
+        "DEF": 24
+      },
+      "fatigue": 15,
+      "stress": 36.94,
+      "loyalty": 73
+    },
+    {
+      "week": 20,
+      "stats": {
+        "LIF": 168,
+        "POW": 63,
+        "INT": 291,
+        "SKI": 210,
+        "SPD": 260,
+        "DEF": 20
+      },
+      "fatigue": 20,
+      "stress": 43.94,
+      "loyalty": 74
+    },
+    {
+      "week": 21,
+      "stats": {
+        "LIF": 168,
+        "POW": 63,
+        "INT": 291,
+        "SKI": 210,
+        "SPD": 260,
+        "DEF": 20
+      },
+      "fatigue": 0,
+      "stress": 28.94,
+      "loyalty": 74
+    }
+  ],
+  "final_stats": {
+    "LIF": 168,
+    "POW": 63,
+    "INT": 291,
+    "SKI": 210,
+    "SPD": 260,
+    "DEF": 20,
+    "loyalty": 74
+  },
+  "breaches": [
+    {
+      "week": 15,
+      "type": "stress",
+      "value": 32.93
+    },
+    {
+      "week": 16,
+      "type": "stress",
+      "value": 32.93
+    },
+    {
+      "week": 17,
+      "type": "stress",
+      "value": 31.94
+    },
+    {
+      "week": 18,
+      "type": "stress",
+      "value": 38.94
+    },
+    {
+      "week": 19,
+      "type": "stress",
+      "value": 36.94
+    },
+    {
+      "week": 20,
+      "type": "stress",
+      "value": 43.94
+    }
+  ],
+  "sim_notes": "Simulated 21 weeks. Lifespan used: 21.",
+  "warnings": []
+}


### PR DESCRIPTION
## Summary
- log previous run with stress breaches
- tweak planner schedule for weeks 15‑18 to incorporate Mint Leaf and rest
- store new simulation result showing no breaches

## Testing
- `python simulate_schedule.py > simulator_output_mod.json`