### PR TITLE
Generate full 340 week schedule

### DIFF
--- a/generate_precocious_schedule.py
+++ b/generate_precocious_schedule.py
@@ -1,0 +1,59 @@
+import json
+
+
+def add_entry(schedule, week, drill, item="None", notes=""):
+    schedule.append({
+        "week": week,
+        "drill": drill,
+        "item": item,
+        "notes": notes
+    })
+
+
+def generate_schedule():
+    schedule = []
+    week = 1
+
+    # Stages 1 & 2: light drills for 8 months (weeks 1-32)
+    for month in range(8):
+        add_entry(schedule, week, "Study", "Mint Leaf", "loyalty build")
+        add_entry(schedule, week + 1, "Dodge")
+        add_entry(schedule, week + 2, "Run")
+        add_entry(schedule, week + 3, "Rest")
+        week += 4
+
+    # Stage 3: ramp up with heavy drills for 8 months (weeks 33-64)
+    for month in range(8):
+        add_entry(schedule, week, "Meditate", "Nuts Oil", "heavy")
+        add_entry(schedule, week + 1, "Leap", "Mint Leaf", "heavy")
+        add_entry(schedule, week + 2, "Study")
+        add_entry(schedule, week + 3, "Rest")
+        week += 4
+
+    # Stages 4-6: prime heavy training for 17 months (weeks 65-132)
+    for month in range(17):
+        add_entry(schedule, week, "Meditate", "Nuts Oil", "prime heavy")
+        drill = "Run" if month % 2 else "Leap"
+        add_entry(schedule, week + 1, drill, "Nuts Oil", "prime heavy")
+        add_entry(schedule, week + 2, "Dodge")
+        add_entry(schedule, week + 3, "Rest")
+        week += 4
+
+    # Stage 7+: taper with light maintenance drills until week 340
+    while week <= 340:
+        add_entry(schedule, week, "Study", "Mint Leaf", "maintenance")
+        if week + 1 <= 340:
+            add_entry(schedule, week + 1, "Dodge")
+        if week + 2 <= 340:
+            add_entry(schedule, week + 2, "Run")
+        if week + 3 <= 340:
+            add_entry(schedule, week + 3, "Rest")
+        week += 4
+
+    return schedule
+
+
+if __name__ == "__main__":
+    schedule = generate_schedule()
+    with open("planner_schedule_full.json", "w") as f:
+        json.dump({"schedule": schedule}, f, indent=2)

--- a/planner_schedule_full.json
+++ b/planner_schedule_full.json
@@ -1,0 +1,2044 @@
+{
+  "schedule": [
+    {
+      "week": 1,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 2,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 3,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 4,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 5,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 6,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 7,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 8,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 9,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 10,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 11,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 12,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 13,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 14,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 15,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 16,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 17,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 18,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 19,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 20,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 21,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 22,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 23,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 24,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 25,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 26,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 27,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 28,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 29,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "loyalty build"
+    },
+    {
+      "week": 30,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 31,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 32,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 33,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 34,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 35,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 36,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 37,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 38,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 39,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 40,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 41,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 42,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 43,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 44,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 45,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 46,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 47,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 48,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 49,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 50,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 51,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 52,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 53,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 54,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 55,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 56,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 57,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 58,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 59,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 60,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 61,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "heavy"
+    },
+    {
+      "week": 62,
+      "drill": "Leap",
+      "item": "Mint Leaf",
+      "notes": "heavy"
+    },
+    {
+      "week": 63,
+      "drill": "Study",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 64,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 65,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 66,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 67,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 68,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 69,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 70,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 71,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 72,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 73,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 74,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 75,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 76,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 77,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 78,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 79,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 80,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 81,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 82,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 83,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 84,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 85,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 86,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 87,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 88,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 89,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 90,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 91,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 92,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 93,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 94,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 95,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 96,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 97,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 98,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 99,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 100,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 101,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 102,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 103,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 104,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 105,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 106,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 107,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 108,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 109,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 110,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 111,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 112,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 113,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 114,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 115,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 116,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 117,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 118,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 119,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 120,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 121,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 122,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 123,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 124,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 125,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 126,
+      "drill": "Run",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 127,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 128,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 129,
+      "drill": "Meditate",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 130,
+      "drill": "Leap",
+      "item": "Nuts Oil",
+      "notes": "prime heavy"
+    },
+    {
+      "week": 131,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 132,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 133,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 134,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 135,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 136,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 137,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 138,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 139,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 140,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 141,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 142,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 143,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 144,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 145,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 146,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 147,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 148,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 149,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 150,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 151,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 152,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 153,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 154,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 155,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 156,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 157,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 158,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 159,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 160,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 161,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 162,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 163,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 164,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 165,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 166,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 167,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 168,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 169,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 170,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 171,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 172,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 173,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 174,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 175,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 176,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 177,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 178,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 179,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 180,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 181,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 182,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 183,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 184,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 185,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 186,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 187,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 188,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 189,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 190,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 191,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 192,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 193,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 194,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 195,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 196,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 197,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 198,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 199,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 200,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 201,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 202,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 203,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 204,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 205,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 206,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 207,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 208,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 209,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 210,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 211,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 212,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 213,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 214,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 215,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 216,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 217,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 218,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 219,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 220,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 221,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 222,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 223,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 224,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 225,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 226,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 227,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 228,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 229,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 230,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 231,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 232,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 233,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 234,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 235,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 236,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 237,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 238,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 239,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 240,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 241,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 242,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 243,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 244,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 245,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 246,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 247,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 248,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 249,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 250,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 251,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 252,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 253,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 254,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 255,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 256,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 257,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 258,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 259,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 260,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 261,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 262,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 263,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 264,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 265,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 266,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 267,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 268,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 269,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 270,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 271,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 272,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 273,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 274,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 275,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 276,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 277,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 278,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 279,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 280,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 281,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 282,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 283,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 284,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 285,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 286,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 287,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 288,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 289,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 290,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 291,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 292,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 293,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 294,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 295,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 296,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 297,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 298,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 299,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 300,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 301,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 302,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 303,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 304,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 305,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 306,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 307,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 308,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 309,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 310,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 311,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 312,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 313,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 314,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 315,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 316,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 317,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 318,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 319,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 320,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 321,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 322,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 323,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 324,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 325,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 326,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 327,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 328,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 329,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 330,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 331,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 332,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 333,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 334,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 335,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 336,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 337,
+      "drill": "Study",
+      "item": "Mint Leaf",
+      "notes": "maintenance"
+    },
+    {
+      "week": 338,
+      "drill": "Dodge",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 339,
+      "drill": "Run",
+      "item": "None",
+      "notes": ""
+    },
+    {
+      "week": 340,
+      "drill": "Rest",
+      "item": "None",
+      "notes": ""
+    }
+  ]
+}

--- a/simulate_schedule.py
+++ b/simulate_schedule.py
@@ -1,11 +1,13 @@
 import json
 import random
+import sys
 
 # Load data
 with open('curated_data.json') as f:
     data = json.load(f)
 
-with open('planner_schedule.json') as f:
+schedule_path = sys.argv[1] if len(sys.argv) > 1 else 'planner_schedule.json'
+with open(schedule_path) as f:
     schedule_data = json.load(f)
 
 # Monster base stats


### PR DESCRIPTION
## Summary
- allow passing schedule path to simulator
- add script to build a full schedule for a Precocious monster
- provide generated 340‑week schedule

## Testing
- `python simulate_schedule.py planner_schedule_full.json`