### PR TITLE
Add second monthly item, ignore food counts

### DIFF
--- a/generate_precocious_schedule.py
+++ b/generate_precocious_schedule.py
@@ -1,13 +1,16 @@
 import json
 
 
-def add_entry(schedule, week, drill, item="None", notes=""):
-    schedule.append({
+def add_entry(schedule, week, drill, item="None", notes="", food=None):
+    entry = {
         "week": week,
         "drill": drill,
         "item": item,
-        "notes": notes
-    })
+        "notes": notes,
+    }
+    if food:
+        entry["food"] = food
+    schedule.append(entry)
 
 
 def generate_schedule():
@@ -16,15 +19,15 @@ def generate_schedule():
 
     # Stages 1 & 2: light drills for 8 months (weeks 1-32)
     for month in range(8):
-        add_entry(schedule, week, "Study", "Mint Leaf", "loyalty build")
+        add_entry(schedule, week, "Study", "Mint Leaf", "loyalty build", food="Cup Jelly")
         add_entry(schedule, week + 1, "Dodge")
-        add_entry(schedule, week + 2, "Run")
+        add_entry(schedule, week + 2, "Run", "Mint Leaf")
         add_entry(schedule, week + 3, "Rest")
         week += 4
 
     # Stage 3: ramp up with heavy drills for 8 months (weeks 33-64)
     for month in range(8):
-        add_entry(schedule, week, "Meditate", "Nuts Oil", "heavy")
+        add_entry(schedule, week, "Meditate", "Nuts Oil", "heavy", food="Cup Jelly")
         add_entry(schedule, week + 1, "Leap", "Mint Leaf", "heavy")
         add_entry(schedule, week + 2, "Study")
         add_entry(schedule, week + 3, "Rest")
@@ -32,7 +35,7 @@ def generate_schedule():
 
     # Stages 4-6: prime heavy training for 17 months (weeks 65-132)
     for month in range(17):
-        add_entry(schedule, week, "Meditate", "Nuts Oil", "prime heavy")
+        add_entry(schedule, week, "Meditate", "Nuts Oil", "prime heavy", food="Cup Jelly")
         drill = "Run" if month % 2 else "Leap"
         add_entry(schedule, week + 1, drill, "Nuts Oil", "prime heavy")
         add_entry(schedule, week + 2, "Dodge")
@@ -41,11 +44,11 @@ def generate_schedule():
 
     # Stage 7+: taper with light maintenance drills until week 340
     while week <= 340:
-        add_entry(schedule, week, "Study", "Mint Leaf", "maintenance")
+        add_entry(schedule, week, "Study", "Mint Leaf", "maintenance", food="Cup Jelly")
         if week + 1 <= 340:
             add_entry(schedule, week + 1, "Dodge")
         if week + 2 <= 340:
-            add_entry(schedule, week + 2, "Run")
+            add_entry(schedule, week + 2, "Run", "Mint Leaf")
         if week + 3 <= 340:
             add_entry(schedule, week + 3, "Rest")
         week += 4

--- a/planner_schedule_full.json
+++ b/planner_schedule_full.json
@@ -16,7 +16,7 @@
     {
       "week": 3,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -41,7 +41,7 @@
     {
       "week": 7,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -66,7 +66,7 @@
     {
       "week": 11,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -91,7 +91,7 @@
     {
       "week": 15,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -116,7 +116,7 @@
     {
       "week": 19,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -141,7 +141,7 @@
     {
       "week": 23,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -166,7 +166,7 @@
     {
       "week": 27,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -191,7 +191,7 @@
     {
       "week": 31,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -841,7 +841,7 @@
     {
       "week": 135,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -866,7 +866,7 @@
     {
       "week": 139,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -891,7 +891,7 @@
     {
       "week": 143,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -916,7 +916,7 @@
     {
       "week": 147,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -941,7 +941,7 @@
     {
       "week": 151,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -966,7 +966,7 @@
     {
       "week": 155,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -991,7 +991,7 @@
     {
       "week": 159,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1016,7 +1016,7 @@
     {
       "week": 163,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1041,7 +1041,7 @@
     {
       "week": 167,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1066,7 +1066,7 @@
     {
       "week": 171,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1091,7 +1091,7 @@
     {
       "week": 175,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1116,7 +1116,7 @@
     {
       "week": 179,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1141,7 +1141,7 @@
     {
       "week": 183,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1166,7 +1166,7 @@
     {
       "week": 187,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1191,7 +1191,7 @@
     {
       "week": 191,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1216,7 +1216,7 @@
     {
       "week": 195,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1241,7 +1241,7 @@
     {
       "week": 199,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1266,7 +1266,7 @@
     {
       "week": 203,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1291,7 +1291,7 @@
     {
       "week": 207,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1316,7 +1316,7 @@
     {
       "week": 211,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1341,7 +1341,7 @@
     {
       "week": 215,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1366,7 +1366,7 @@
     {
       "week": 219,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1391,7 +1391,7 @@
     {
       "week": 223,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1416,7 +1416,7 @@
     {
       "week": 227,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1441,7 +1441,7 @@
     {
       "week": 231,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1466,7 +1466,7 @@
     {
       "week": 235,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1491,7 +1491,7 @@
     {
       "week": 239,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1516,7 +1516,7 @@
     {
       "week": 243,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1541,7 +1541,7 @@
     {
       "week": 247,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1566,7 +1566,7 @@
     {
       "week": 251,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1591,7 +1591,7 @@
     {
       "week": 255,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1616,7 +1616,7 @@
     {
       "week": 259,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1641,7 +1641,7 @@
     {
       "week": 263,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1666,7 +1666,7 @@
     {
       "week": 267,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1691,7 +1691,7 @@
     {
       "week": 271,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1716,7 +1716,7 @@
     {
       "week": 275,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1741,7 +1741,7 @@
     {
       "week": 279,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1766,7 +1766,7 @@
     {
       "week": 283,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1791,7 +1791,7 @@
     {
       "week": 287,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1816,7 +1816,7 @@
     {
       "week": 291,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1841,7 +1841,7 @@
     {
       "week": 295,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1866,7 +1866,7 @@
     {
       "week": 299,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1891,7 +1891,7 @@
     {
       "week": 303,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1916,7 +1916,7 @@
     {
       "week": 307,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1941,7 +1941,7 @@
     {
       "week": 311,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1966,7 +1966,7 @@
     {
       "week": 315,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -1991,7 +1991,7 @@
     {
       "week": 319,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -2016,7 +2016,7 @@
     {
       "week": 323,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -2041,7 +2041,7 @@
     {
       "week": 327,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -2066,7 +2066,7 @@
     {
       "week": 331,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -2091,7 +2091,7 @@
     {
       "week": 335,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {
@@ -2116,7 +2116,7 @@
     {
       "week": 339,
       "drill": "Run",
-      "item": "None",
+      "item": "Mint Leaf",
       "notes": ""
     },
     {


### PR DESCRIPTION
## Summary
- allow `add_entry` to specify a monthly food
- insert a second Mint Leaf use during light/maintenance months
- include food on the first week of each month when generating the schedule

## Testing
- `python3 -m py_compile generate_precocious_schedule.py simulate_schedule.py`